### PR TITLE
Added unit tests to verify API key length validation in VirusTotal class

### DIFF
--- a/VTResponseParser/Constants.cs
+++ b/VTResponseParser/Constants.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VirusTotal
+{
+    /// <summary>
+    /// Contains constant values used in the VirusTotal project.
+    /// </summary>
+    internal class Constants
+    {
+        public const string APIKeyTooShortErrorMessage = "Invalid API key length. The API key should be 64 characters long.";
+    }
+}

--- a/VTResponseParser/VT.cs
+++ b/VTResponseParser/VT.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Diagnostics;
+using System.Reflection.Metadata;
 
 namespace VirusTotal
 {
@@ -13,6 +14,9 @@ namespace VirusTotal
 
         public VT(string apiKey)
         {
+            if (apiKey.Length != 64)
+                throw new ArgumentException(Constants.APIKeyTooShortErrorMessage);
+            
             ApiKey = apiKey;
             httpClient = CreateHttpClient();
         }

--- a/VirusTotalTests/APIErrorTests.cs
+++ b/VirusTotalTests/APIErrorTests.cs
@@ -6,17 +6,37 @@ namespace VirusTotalTests
     public class APIErrorTests
     {
         [Fact]
-        public async  Task VT_InvalidAPIKey()
+        public void InvalidApiKeyLength_ThrowsException()
         {
             // Arrange
-            VT vt = new("ThisKeyIsNotValid");
+            string InvalidApiKeyLength = new string('a', 32);
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => new VT(InvalidApiKeyLength));
+        }
+
+        [Fact]
+        public void ValidApiKeyLength_NoExecption()
+        {
+            // Arrange
+            string ValidApiKeyLength = new string('a', 64);
+
+            // Act & Assert
+            Assert.Null(Record.Exception(() => new VT(ValidApiKeyLength)));
+        }
+
+        [Fact]
+        public async Task GetReportAsync_InvalidAPIKey_ReturnsErrorCode()
+        {
+            // Arrange
+            string testAPIKey = new string('a', 64);
+            VT vt = new(testAPIKey);
 
             // Act
             ResponseParser vtScanReport = await vt.GetReportAsync("ThisReportDoesNotExist");
 
             // Assert
             Assert.NotNull(vtScanReport.ErrorCode);
-  
         }
     }
 }

--- a/Widget/Constants.cs
+++ b/Widget/Constants.cs
@@ -8,8 +8,15 @@ using System.Reflection;
 
 namespace Widget
 {
+    /// <summary>
+    /// Contains constant values used in the Widget project.
+    /// </summary>
     public class Constants
     {
+        // VirusTotal project have its own Constants
+
+
+        // Mutex Messages
         public const string AlreadyRunningMessage = "Widget is already running.\n\n Please close the existing instance before launching a new one.";
         public const string AlreadyRunningMessageTitle = "Widget already running";
 


### PR DESCRIPTION
- Created a unit test to validate that an exception is thrown when the API key is shorter than 64 characters
- Added a unit test to ensure that no exception is thrown when the API key length is correct
- Implemented a key length check in the VirusTotal class constructor to enforce a 64-character key requirement